### PR TITLE
add support to include application inference profiles as models

### DIFF
--- a/deployment/BedrockProxy.template
+++ b/deployment/BedrockProxy.template
@@ -185,6 +185,7 @@ Resources:
             Ref: DefaultModelId
           DEFAULT_EMBEDDING_MODEL: cohere.embed-multilingual-v3
           ENABLE_CROSS_REGION_INFERENCE: "true"
+          ENABLE_APPLICATION_INFERENCE_PROFILES: "true"
       MemorySize: 1024
       PackageType: Image
       Role:

--- a/deployment/BedrockProxyFargate.template
+++ b/deployment/BedrockProxyFargate.template
@@ -222,6 +222,8 @@ Resources:
               Value: cohere.embed-multilingual-v3
             - Name: ENABLE_CROSS_REGION_INFERENCE
               Value: "true"
+            - Name: ENABLE_APPLICATION_INFERENCE_PROFILES
+              Value: "true"
           Essential: true
           Image:
             Fn::Join:

--- a/src/api/setting.py
+++ b/src/api/setting.py
@@ -13,6 +13,15 @@ Use OpenAI-Compatible RESTful APIs for Amazon Bedrock models.
 
 DEBUG = os.environ.get("DEBUG", "false").lower() != "false"
 AWS_REGION = os.environ.get("AWS_REGION", "us-west-2")
-DEFAULT_MODEL = os.environ.get("DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0")
-DEFAULT_EMBEDDING_MODEL = os.environ.get("DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3")
-ENABLE_CROSS_REGION_INFERENCE = os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
+DEFAULT_MODEL = os.environ.get(
+    "DEFAULT_MODEL", "anthropic.claude-3-sonnet-20240229-v1:0"
+)
+DEFAULT_EMBEDDING_MODEL = os.environ.get(
+    "DEFAULT_EMBEDDING_MODEL", "cohere.embed-multilingual-v3"
+)
+ENABLE_CROSS_REGION_INFERENCE = (
+    os.environ.get("ENABLE_CROSS_REGION_INFERENCE", "true").lower() != "false"
+)
+ENABLE_APPLICATION_INFERENCE_PROFILES = (
+    os.environ.get("ENABLE_APPLICATION_INFERENCE_PROFILES", "true").lower() != "false"
+)


### PR DESCRIPTION
New feature support: Add support for listing application defined inference profiles as models

Description of changes:
As AWS uses system defined inference profiles for cross region inference models/profiles, we can also define custom application defined inference profiles based on foundation models.

This gives flexibility to define profiles for different purposes for segregation and cost tracking purposes. I am using it in a project for cost tracking purposes using AWS tags attached to application inference profiles.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.