### PR TITLE
Deploy image to pvds ecr

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,24 +118,16 @@ jobs:
           aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
           aws-region: us-west-2
 
-      - name: Check if bucket exists
-        id: check_bucket
+      - name: Check and create bucket if it does not exist
         run: |
           bucket_name=falcon-ai-bedrock-accesss-gateway
-          if aws s3api list-buckets --query "Buckets[?Name=='$bucket_name'].Name" --output text | grep -q "$bucket_name"; then
-            echo "Bucket exists"
-            echo "::set-output name=bucket_exists::true"
+          region=us-west-2
+          if aws s3api head-bucket --bucket "$bucket_name" 2>/dev/null; then
+            echo "Bucket already exists."
           else
-            echo "Bucket does not exist"
-            echo "::set-output name=bucket_exists::false"
+            echo "Bucket does not exist. Creating bucket..."
+            aws s3api create-bucket --bucket "$bucket_name" --region "$region" --create-bucket-configuration LocationConstraint="$region"
           fi
-
-      - name: Create new bucket
-        if: steps.check_bucket.outputs.bucket_exists == 'false'
-        run: |
-          bucket_name=falcon-ai-bedrock-accesss-gateway
-          aws s3api create-bucket --bucket $bucket_name --region us-west-2 --create-bucket-configuration LocationConstraint=us-west-2
-
       - name: Copy Deployment Templates to S3
         env:
           S3_BUCKET: falcon-ai-bedrock-accesss-gateway

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,7 +88,8 @@ jobs:
       - name: Deploy CloudFormation Stack
         run: |
           stack_name="BedrockProxyStackTest"
-          template_file="BedrockProxy.template"
+          s3_bucket="falcon-ai-bedrock-accesss-gateway"
+          template_file="s3://$s3_bucket/BedrockProxy.template"
           region="us-west-2"
           api_key_secret_arn="arn:aws:secretsmanager:us-west-2:123456789012:secret:MyApiKeySecret"
           default_model_id="anthropic.claude-3-sonnet-20240229-v1:0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build Docker image
         run: |
           cd src
-          docker build -t bedrock-access-gateway:latest .
+          docker buildx build --platform linux/arm64 -t bedrock-access-gateway:latest .
 
       # Step 5: Tag the Docker image
       - name: Tag Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,42 +36,42 @@ jobs:
   #       run: |-
   #         cd scripts
   #         bash push-to-ecr.sh
-  build-and-push:
-    runs-on: ubuntu-latest
-
-    steps:
-      # Step 1: Checkout the repository
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      # Step 2: Configure AWS credentials
-      - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v2
-        with:
-          aws-access-key-id: ${{ secrets.GH_ACTIONS_AWS_ACCESS_KEY_ID_DEVELOPMENT }}
-          aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
-          aws-region: us-west-2
-
-      # Step 3: Log in to Amazon ECR
-      - name: Log in to Amazon ECR
-        uses: aws-actions/amazon-ecr-login@v1
-
-      # Step 4: Build the Docker image
-      - name: Build Docker image
-        run: |
-          cd src
-          docker buildx build --platform linux/x86_64 -t bedrock-access-gateway:latest .
-
-      # Step 5: Tag the Docker image
-      - name: Tag Docker image
-        run: |
-          docker tag bedrock-access-gateway:latest 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
-
-
-      # Step 6: Push the Docker image to ECR
-      - name: Push Docker image to ECR
-        run: |
-          docker push 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
+#  build-and-push:
+#    runs-on: ubuntu-latest
+#
+#    steps:
+#      # Step 1: Checkout the repository
+#      - name: Checkout code
+#        uses: actions/checkout@v3
+#
+#      # Step 2: Configure AWS credentials
+#      - name: Configure AWS credentials
+#        uses: aws-actions/configure-aws-credentials@v2
+#        with:
+#          aws-access-key-id: ${{ secrets.GH_ACTIONS_AWS_ACCESS_KEY_ID_DEVELOPMENT }}
+#          aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
+#          aws-region: us-west-2
+#
+#      # Step 3: Log in to Amazon ECR
+#      - name: Log in to Amazon ECR
+#        uses: aws-actions/amazon-ecr-login@v1
+#
+#      # Step 4: Build the Docker image
+#      - name: Build Docker image
+#        run: |
+#          cd src
+#          docker buildx build --platform linux/x86_64 -t bedrock-access-gateway:latest .
+#
+#      # Step 5: Tag the Docker image
+#      - name: Tag Docker image
+#        run: |
+#          docker tag bedrock-access-gateway:latest 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
+#
+#
+#      # Step 6: Push the Docker image to ECR
+#      - name: Push Docker image to ECR
+#        run: |
+#          docker push 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
 
 #  cfn_templates:
 #    runs-on: ubuntu-latest
@@ -96,3 +96,48 @@ jobs:
 #          S3_BUCKET: ${{ secrets.ASSET_BUCKET }}
 #          S3_PREFIX: bedrock-access-gateway/latest/
 #        run: aws s3 sync deployment/ s3://$S3_BUCKET/$S3_PREFIX --acl public-read
+
+
+  cfn_templates:
+    name: Development
+    environment: development
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
+
+      - name: Setup python
+        uses: actions/setup-python@v4
+        with:
+          python-version: "3.12"
+
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-access-key-id: ${{ secrets.GH_ACTIONS_AWS_ACCESS_KEY_ID_DEVELOPMENT }}
+          aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
+          aws-region: ${{ secrets.AWS_REGION_DEVELOPMENT_US_WEST_2 }}
+
+      - name: Check if bucket exists
+        id: check_bucket
+        run: |
+          bucket_name=${{ vars.DEV_DEPLOY_BUCKET }}
+          if aws s3api list-buckets --query "Buckets[?Name=='$bucket_name'].Name" --output text | grep -q "$bucket_name"; then
+            echo "Bucket exists"
+            echo "::set-output name=bucket_exists::true"
+          else
+            echo "Bucket does not exist"
+            echo "::set-output name=bucket_exists::false"
+          fi
+
+      - name: Create new bucket
+        if: steps.check_bucket.outputs.bucket_exists == 'false'
+        run: |
+          bucket_name=falcon-ai-bedrock-accesss-gateway
+          aws s3api create-bucket --bucket $bucket_name --region us-west-2 --create-bucket-configuration LocationConstraint=us-west-2
+
+      - name: Copy Deployment Templates to S3
+        env:
+          S3_BUCKET: falcon-ai-bedrock-accesss-gateway
+          S3_PREFIX: latest/
+        run: aws s3 sync deployment/ s3://$S3_BUCKET/$S3_PREFIX --acl public-read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,7 +89,7 @@ jobs:
         run: |
           stack_name="BedrockProxyStackTest"
           s3_bucket="falcon-ai-bedrock-accesss-gateway"
-          template_file="s3://$s3_bucket/BedrockProxy.template"
+          template_url="https://$s3_bucket.s3.us-west-2.amazonaws.com/BedrockProxy.template"
           region="us-west-2"
           api_key_secret_arn="arn:aws:secretsmanager:us-west-2:123456789012:secret:MyApiKeySecret"
           default_model_id="anthropic.claude-3-sonnet-20240229-v1:0"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -90,7 +90,6 @@ jobs:
          stack_name="BedrockProxyStackTest"
          template_file="./deployment/BedrockProxy.template" # Local file path
          region="us-west-2"
-         api_key_secret_arn="arn:aws:secretsmanager:us-west-2:123456789012:secret:MyApiKeySecret"
          default_model_id="anthropic.claude-3-sonnet-20240229-v1:0"
 
          aws cloudformation deploy \
@@ -99,5 +98,5 @@ jobs:
            --region "$region" \
            --capabilities CAPABILITY_NAMED_IAM \
            --parameter-overrides \
-             ApiKeySecretArn="$api_key_secret_arn" \
+             BedrockGatewaySecret=bedrock-agi \
              DefaultModelId="$default_model_id"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,92 +10,43 @@ on:
         required: false
         default: 'manually publish the pre-built ecr images'
 jobs:
-  # ecr_images:
-  #   runs-on: ubuntu-latest
-  #   permissions:
-  #     id-token: write
-  #     contents: read
-  #   env:
-  #     iam_role_to_assume: ${{ secrets.ROLE_ARN }}
-  #   steps:
-  #     - name: Set up QEMU
-  #       uses: docker/setup-qemu-action@v3
-  #     - name: Set up Docker Buildx
-  #       uses: docker/setup-buildx-action@v3
-  #     - name: Checkout
-  #       uses: actions/checkout@v4
-  #       with:
-  #         fetch-depth: 0
-  #     - name: Configure AWS Credentials
-  #       if: ${{ env.iam_role_to_assume != '' }}
-  #       uses: aws-actions/configure-aws-credentials@v4
-  #       with:
-  #         role-to-assume: ${{ env.iam_role_to_assume }}
-  #         aws-region: us-east-1
-  #     - name: Build and Publish
-  #       run: |-
-  #         cd scripts
-  #         bash push-to-ecr.sh
-#  build-and-push:
-#    runs-on: ubuntu-latest
-#
-#    steps:
-#      # Step 1: Checkout the repository
-#      - name: Checkout code
-#        uses: actions/checkout@v3
-#
-#      # Step 2: Configure AWS credentials
-#      - name: Configure AWS credentials
-#        uses: aws-actions/configure-aws-credentials@v2
-#        with:
-#          aws-access-key-id: ${{ secrets.GH_ACTIONS_AWS_ACCESS_KEY_ID_DEVELOPMENT }}
-#          aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
-#          aws-region: us-west-2
-#
-#      # Step 3: Log in to Amazon ECR
-#      - name: Log in to Amazon ECR
-#        uses: aws-actions/amazon-ecr-login@v1
-#
-#      # Step 4: Build the Docker image
-#      - name: Build Docker image
-#        run: |
-#          cd src
-#          docker buildx build --platform linux/x86_64 -t bedrock-access-gateway:latest .
-#
-#      # Step 5: Tag the Docker image
-#      - name: Tag Docker image
-#        run: |
-#          docker tag bedrock-access-gateway:latest 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
-#
-#
-#      # Step 6: Push the Docker image to ECR
-#      - name: Push Docker image to ECR
-#        run: |
-#          docker push 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
 
-#  cfn_templates:
-#    runs-on: ubuntu-latest
-#    permissions:
-#      id-token: write
-#    needs: ecr_images
-#    env:
-#      iam_role_to_assume: ${{ secrets.ROLE_ARN }}
-#    steps:
-#      - name: Checkout
-#        uses: actions/checkout@v4
-#        with:
-#          fetch-depth: 0
-#      - name: Configure AWS Credentials
-#        if: ${{ env.iam_role_to_assume != '' }}
-#        uses: aws-actions/configure-aws-credentials@v4
-#        with:
-#          role-to-assume: ${{ env.iam_role_to_assume }}
-#          aws-region: us-east-1
-#      - name: Copy Deployment Templates to S3
-#        env:
-#          S3_BUCKET: ${{ secrets.ASSET_BUCKET }}
-#          S3_PREFIX: bedrock-access-gateway/latest/
-#        run: aws s3 sync deployment/ s3://$S3_BUCKET/$S3_PREFIX --acl public-read
+  build-and-push:
+    runs-on: ubuntu-latest
+
+    steps:
+      # Step 1: Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Configure AWS credentials
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
+          aws-access-key-id: ${{ secrets.GH_ACTIONS_AWS_ACCESS_KEY_ID_DEVELOPMENT }}
+          aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
+          aws-region: us-west-2
+
+      # Step 3: Log in to Amazon ECR
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+
+      # Step 4: Build the Docker image
+      - name: Build Docker image
+        run: |
+          cd src
+          docker buildx build --platform linux/x86_64 -t bedrock-access-gateway:latest .
+
+      # Step 5: Tag the Docker image
+      - name: Tag Docker image
+        run: |
+          docker tag bedrock-access-gateway:latest 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
+
+
+      # Step 6: Push the Docker image to ECR
+      - name: Push Docker image to ECR
+        run: |
+          docker push 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
 
 
   cfn_templates:
@@ -133,3 +84,20 @@ jobs:
           S3_BUCKET: falcon-ai-bedrock-accesss-gateway
 
         run: aws s3 sync deployment/ s3://$S3_BUCKET/
+
+      - name: Deploy CloudFormation Stack
+        run: |
+          stack_name="BedrockProxyStackTest"
+          template_file="BedrockProxy.template"
+          region="us-west-2"
+          api_key_secret_arn="arn:aws:secretsmanager:us-west-2:123456789012:secret:MyApiKeySecret"
+          default_model_id="anthropic.claude-3-sonnet-20240229-v1:0"
+
+          aws cloudformation deploy \
+            --stack-name "$stack_name" \
+            --template-file "$template_file" \
+            --region "$region" \
+            --capabilities CAPABILITY_NAMED_IAM \
+            --parameter-overrides \
+              ApiKeySecretArn="$api_key_secret_arn" \
+              DefaultModelId="$default_model_id"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: release
 on:
+  push:
+    branches:
+      - main 
   workflow_dispatch:
     inputs:
       reason:
@@ -7,52 +10,89 @@ on:
         required: false
         default: 'manually publish the pre-built ecr images'
 jobs:
-  ecr_images:
+  # ecr_images:
+  #   runs-on: ubuntu-latest
+  #   permissions:
+  #     id-token: write
+  #     contents: read
+  #   env:
+  #     iam_role_to_assume: ${{ secrets.ROLE_ARN }}
+  #   steps:
+  #     - name: Set up QEMU
+  #       uses: docker/setup-qemu-action@v3
+  #     - name: Set up Docker Buildx
+  #       uses: docker/setup-buildx-action@v3
+  #     - name: Checkout
+  #       uses: actions/checkout@v4
+  #       with:
+  #         fetch-depth: 0
+  #     - name: Configure AWS Credentials
+  #       if: ${{ env.iam_role_to_assume != '' }}
+  #       uses: aws-actions/configure-aws-credentials@v4
+  #       with:
+  #         role-to-assume: ${{ env.iam_role_to_assume }}
+  #         aws-region: us-east-1
+  #     - name: Build and Publish
+  #       run: |-
+  #         cd scripts
+  #         bash push-to-ecr.sh
+  build-and-push:
     runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: read
-    env:
-      iam_role_to_assume: ${{ secrets.ROLE_ARN }}
+
     steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      - name: Checkout
-        uses: actions/checkout@v4
+      # Step 1: Checkout the repository
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      # Step 2: Configure AWS credentials
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          fetch-depth: 0
-      - name: Configure AWS Credentials
-        if: ${{ env.iam_role_to_assume != '' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.iam_role_to_assume }}
-          aws-region: us-east-1
-      - name: Build and Publish
-        run: |-
-          cd scripts
-          bash push-to-ecr.sh
-  cfn_templates:
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-    needs: ecr_images
-    env:
-      iam_role_to_assume: ${{ secrets.ROLE_ARN }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Configure AWS Credentials
-        if: ${{ env.iam_role_to_assume != '' }}
-        uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.iam_role_to_assume }}
-          aws-region: us-east-1
-      - name: Copy Deployment Templates to S3
-        env:
-          S3_BUCKET: ${{ secrets.ASSET_BUCKET }}
-          S3_PREFIX: bedrock-access-gateway/latest/
-        run: aws s3 sync deployment/ s3://$S3_BUCKET/$S3_PREFIX --acl public-read
+          aws-access-key-id: ${{ secrets.GH_ACTIONS_AWS_ACCESS_KEY_ID_DEVELOPMENT }}
+          aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
+          aws-region: us-west-2
+
+      # Step 3: Log in to Amazon ECR
+      - name: Log in to Amazon ECR
+        uses: aws-actions/amazon-ecr-login@v1
+
+      # Step 4: Build the Docker image
+      - name: Build Docker image
+        run: |
+          cd src
+          docker build -t bedrock-access-gateway:latest .
+
+      # Step 5: Tag the Docker image
+      - name: Tag Docker image
+        run: |
+          docker tag bedrock-access-gateway:latest 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
+
+
+      # Step 6: Push the Docker image to ECR
+      - name: Push Docker image to ECR
+        run: |
+          docker push 835453518493.dkr.ecr.us-west-2.amazonaws.com/bedrock-access-gateway:latest
+
+#  cfn_templates:
+#    runs-on: ubuntu-latest
+#    permissions:
+#      id-token: write
+#    needs: ecr_images
+#    env:
+#      iam_role_to_assume: ${{ secrets.ROLE_ARN }}
+#    steps:
+#      - name: Checkout
+#        uses: actions/checkout@v4
+#        with:
+#          fetch-depth: 0
+#      - name: Configure AWS Credentials
+#        if: ${{ env.iam_role_to_assume != '' }}
+#        uses: aws-actions/configure-aws-credentials@v4
+#        with:
+#          role-to-assume: ${{ env.iam_role_to_assume }}
+#          aws-region: us-east-1
+#      - name: Copy Deployment Templates to S3
+#        env:
+#          S3_BUCKET: ${{ secrets.ASSET_BUCKET }}
+#          S3_PREFIX: bedrock-access-gateway/latest/
+#        run: aws s3 sync deployment/ s3://$S3_BUCKET/$S3_PREFIX --acl public-read

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,7 +96,7 @@ jobs:
 
           aws cloudformation deploy \
             --stack-name "$stack_name" \
-            --template-file "$template_file" \
+            --template-url "$template_url" \
             --region "$region" \
             --capabilities CAPABILITY_NAMED_IAM \
             --parameter-overrides \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,7 +121,7 @@ jobs:
       - name: Check if bucket exists
         id: check_bucket
         run: |
-          bucket_name=${{ vars.DEV_DEPLOY_BUCKET }}
+          bucket_name=falcon-ai-bedrock-accesss-gateway
           if aws s3api list-buckets --query "Buckets[?Name=='$bucket_name'].Name" --output text | grep -q "$bucket_name"; then
             echo "Bucket exists"
             echo "::set-output name=bucket_exists::true"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,20 +85,19 @@ jobs:
 
         run: aws s3 sync deployment/ s3://$S3_BUCKET/
 
-      - name: Deploy CloudFormation Stack
-        run: |
-          stack_name="BedrockProxyStackTest"
-          s3_bucket="falcon-ai-bedrock-accesss-gateway"
-          template_file="s3://$s3_bucket/BedrockProxy.template"
-          region="us-west-2"
-          api_key_secret_arn="arn:aws:secretsmanager:us-west-2:123456789012:secret:MyApiKeySecret"
-          default_model_id="anthropic.claude-3-sonnet-20240229-v1:0"
+     - name: Deploy CloudFormation Stack
+       run: |
+         stack_name="BedrockProxyStackTest"
+         template_file="./deployment/BedrockProxy.template" # Local file path
+         region="us-west-2"
+         api_key_secret_arn="arn:aws:secretsmanager:us-west-2:123456789012:secret:MyApiKeySecret"
+         default_model_id="anthropic.claude-3-sonnet-20240229-v1:0"
 
-          aws cloudformation deploy \
-            --stack-name "$stack_name" \
-            --template-file "$template_file" \
-            --region "$region" \
-            --capabilities CAPABILITY_NAMED_IAM \
-            --parameter-overrides \
-              ApiKeySecretArn="$api_key_secret_arn" \
-              DefaultModelId="$default_model_id"
+         aws cloudformation deploy \
+           --stack-name "$stack_name" \
+           --template-file "$template_file" \
+           --region "$region" \
+           --capabilities CAPABILITY_NAMED_IAM \
+           --parameter-overrides \
+             ApiKeySecretArn="$api_key_secret_arn" \
+             DefaultModelId="$default_model_id"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -140,4 +140,4 @@ jobs:
         env:
           S3_BUCKET: falcon-ai-bedrock-accesss-gateway
           S3_PREFIX: latest/
-        run: aws s3 sync deployment/ s3://$S3_BUCKET/$S3_PREFIX --acl public-read
+        run: aws s3 sync deployment/ s3://$S3_BUCKET/$S3_PREFIX

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,26 +69,10 @@ jobs:
           aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
           aws-region: us-west-2
 
-      - name: Check and create bucket if it does not exist
-        run: |
-          bucket_name=falcon-ai-bedrock-accesss-gateway
-          region=us-west-2
-          if aws s3api head-bucket --bucket "$bucket_name" 2>/dev/null; then
-            echo "Bucket already exists."
-          else
-            echo "Bucket does not exist. Creating bucket..."
-            aws s3api create-bucket --bucket "$bucket_name" --region "$region" --create-bucket-configuration LocationConstraint="$region"
-          fi
-      - name: Copy Deployment Templates to S3
-        env:
-          S3_BUCKET: falcon-ai-bedrock-accesss-gateway
-
-        run: aws s3 sync deployment/ s3://$S3_BUCKET/
-
       - name: Deploy CloudFormation Stack
         run: |
-         stack_name="BedrockProxyStackTest"
-         template_file="./deployment/BedrockProxy.template" # Local file path
+         stack_name="Bedrock-Access-Gateway"
+         template_file="./deployment/BedrockProxy.template"
          region="us-west-2"
          default_model_id="anthropic.claude-3-sonnet-20240229-v1:0"
 
@@ -98,5 +82,5 @@ jobs:
            --region "$region" \
            --capabilities CAPABILITY_NAMED_IAM \
            --parameter-overrides \
-             SecretValue=bedrock-agi \
+             SecretValue=${{ secrets.BEDROCK_GATEWAY_SECRET }} \
              DefaultModelId="$default_model_id"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,7 @@ jobs:
         run: aws s3 sync deployment/ s3://$S3_BUCKET/
 
       - name: Deploy CloudFormation Stack
-       run: |
+        run: |
          stack_name="BedrockProxyStackTest"
          template_file="./deployment/BedrockProxy.template" # Local file path
          region="us-west-2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
       - name: Build Docker image
         run: |
           cd src
-          docker buildx build --platform linux/arm64 -t bedrock-access-gateway:latest .
+          docker buildx build --platform linux/x86_64 -t bedrock-access-gateway:latest .
 
       # Step 5: Tag the Docker image
       - name: Tag Docker image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,5 +98,5 @@ jobs:
            --region "$region" \
            --capabilities CAPABILITY_NAMED_IAM \
            --parameter-overrides \
-             BedrockGatewaySecret=bedrock-agi \
+             SecretValue=bedrock-agi \
              DefaultModelId="$default_model_id"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
         with:
           aws-access-key-id: ${{ secrets.GH_ACTIONS_AWS_ACCESS_KEY_ID_DEVELOPMENT }}
           aws-secret-access-key: ${{ secrets.GH_ACTIONS_AWS_SECRET_ACCESS_KEY_DEVELOPMENT }}
-          aws-region: ${{ secrets.AWS_REGION_DEVELOPMENT_US_WEST_2 }}
+          aws-region: us-west-2
 
       - name: Check if bucket exists
         id: check_bucket

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -89,14 +89,14 @@ jobs:
         run: |
           stack_name="BedrockProxyStackTest"
           s3_bucket="falcon-ai-bedrock-accesss-gateway"
-          template_url="https://$s3_bucket.s3.us-west-2.amazonaws.com/BedrockProxy.template"
+          template_file="s3://$s3_bucket/BedrockProxy.template"
           region="us-west-2"
           api_key_secret_arn="arn:aws:secretsmanager:us-west-2:123456789012:secret:MyApiKeySecret"
           default_model_id="anthropic.claude-3-sonnet-20240229-v1:0"
 
           aws cloudformation deploy \
             --stack-name "$stack_name" \
-            --template-url "$template_url" \
+            --template-file "$template_file" \
             --region "$region" \
             --capabilities CAPABILITY_NAMED_IAM \
             --parameter-overrides \

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,5 +131,5 @@ jobs:
       - name: Copy Deployment Templates to S3
         env:
           S3_BUCKET: falcon-ai-bedrock-accesss-gateway
-          S3_PREFIX: latest/
-        run: aws s3 sync deployment/ s3://$S3_BUCKET/$S3_PREFIX
+
+        run: aws s3 sync deployment/ s3://$S3_BUCKET/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,7 +85,7 @@ jobs:
 
         run: aws s3 sync deployment/ s3://$S3_BUCKET/
 
-     - name: Deploy CloudFormation Stack
+      - name: Deploy CloudFormation Stack
        run: |
          stack_name="BedrockProxyStackTest"
          template_file="./deployment/BedrockProxy.template" # Local file path

--- a/deployment/BedrockProxy.template
+++ b/deployment/BedrockProxy.template
@@ -1,14 +1,24 @@
 Description: Bedrock Access Gateway - OpenAI-compatible RESTful APIs for Amazon Bedrock
 Parameters:
-  ApiKeySecretArn:
-    Type: String
-    AllowedPattern: ^arn:aws:secretsmanager:.*$
-    Description: The secret ARN in Secrets Manager used to store the API Key
   DefaultModelId:
     Type: String
     Default: anthropic.claude-3-sonnet-20240229-v1:0
     Description: The default model ID, please make sure the model ID is supported in the current region
+  SecretValue:
+    Type: String
+    Description: The value to store in the secret
+    NoEcho: true # Ensures the value is not displayed in logs or outputs  
 Resources:
+  BedrockGatewaySecret:
+    Type: AWS::SecretsManager::Secret
+    Properties:
+      Name: BedrockGatewaySecret
+      Description: BedrockGatewaySecret created by CloudFormation
+      SecretString: 
+        Fn::Sub: |
+          {
+            "api_key": "${SecretValue}"
+          }
   VPCB9E5F0B4:
     Type: AWS::EC2::VPC
     Properties:
@@ -156,7 +166,7 @@ Resources:
               - secretsmanager:DescribeSecret
             Effect: Allow
             Resource:
-              Ref: ApiKeySecretArn
+              Ref: BedrockGatewaySecret
         Version: "2012-10-17"
       PolicyName: ProxyApiHandlerServiceRoleDefaultPolicy86681202
       Roles:
@@ -180,7 +190,7 @@ Resources:
         Variables:
           DEBUG: "false"
           API_KEY_SECRET_ARN:
-            Ref: ApiKeySecretArn
+            Ref: BedrockGatewaySecret
           DEFAULT_MODEL:
             Ref: DefaultModelId
           DEFAULT_EMBEDDING_MODEL: cohere.embed-multilingual-v3
@@ -277,4 +287,7 @@ Outputs:
               - ProxyALB87756780
               - DNSName
           - /api/v1
+  SecretArn:
+    Description: The ARN of the created secret
+    Value: !Ref BedrockGatewaySecret
 

--- a/deployment/BedrockProxy.template
+++ b/deployment/BedrockProxy.template
@@ -165,16 +165,16 @@ Resources:
     Type: AWS::Lambda::Function
     Properties:
       Architectures:
-        - arm64
+        - x86_64
       Code:
         ImageUri:
           Fn::Join:
             - ""
-            - - 366590864501.dkr.ecr.
+            - - 835453518493.dkr.ecr.
               - Ref: AWS::Region
               - "."
               - Ref: AWS::URLSuffix
-              - /bedrock-proxy-api:latest
+              - /bedrock-access-gateway:latest
       Description: Bedrock Proxy API Handler
       Environment:
         Variables:

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,13 +1,9 @@
 FROM public.ecr.aws/lambda/python:3.12
 
-# Copy the contents of the api directory to the root of the container
-COPY ./api/* .
+COPY ./api ./api
 
-# Copy the requirements file
 COPY requirements.txt .
 
-# Install dependencies
 RUN pip3 install -r requirements.txt -U --no-cache-dir
 
-# Set the Lambda handler
-CMD [ "app.handler" ]
+CMD [ "api.app.handler" ]

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -1,9 +1,13 @@
 FROM public.ecr.aws/lambda/python:3.12
 
-COPY ./api ./api
+# Copy the contents of the api directory to the root of the container
+COPY ./api/* .
 
+# Copy the requirements file
 COPY requirements.txt .
 
+# Install dependencies
 RUN pip3 install -r requirements.txt -U --no-cache-dir
 
-CMD [ "api.app.handler" ]
+# Set the Lambda handler
+CMD [ "app.handler" ]


### PR DESCRIPTION
Description of changes:

- Bedrock access gateway docker image will now be uploaded to the DS DEV AWS account
- Deployment of the Bedrock access gateway is now fully automated via cfn
- By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.